### PR TITLE
Cap `pandas` to less than `3.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "pandas >= 2.2.3 < 3.0",
+    "pandas >= 2.2.3,<3.0",
     "tqdm",
     "openpyxl",
     "xlsxwriter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "pandas >= 2.2.3",
+    "pandas >= 2.2.3 < 3.0",
     "tqdm",
     "openpyxl",
     "xlsxwriter",


### PR DESCRIPTION
With the latest release of `pandas` the workflows are breaking, in order for them to run daily we can just cap the pandas version until we are sure if we want to support 3.0.