### PR TITLE
Change environment from monthly to weekly

### DIFF
--- a/.github/workflows/monthly_collection.yaml
+++ b/.github/workflows/monthly_collection.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   monthly_github_collection:
-    environment: monthly
+    environment: weekly
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/monthly_collection.yaml
+++ b/.github/workflows/monthly_collection.yaml
@@ -36,7 +36,7 @@ jobs:
     - name: Consolidate GitHub Data
       run: |
         uv run gitmetrics consolidate \
-          --config-file monthly_extraction_config.yaml \
+          --config-file weekly_extraction_config.yaml monthly_extraction_config.yaml \
           --output-folder ${{ secrets.OUTPUT_FOLDER }}
       env:
         PYDRIVE_CREDENTIALS: ${{ secrets.PYDRIVE_CREDENTIALS }}

--- a/.github/workflows/weekly_collection.yaml
+++ b/.github/workflows/weekly_collection.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: Consolidate GitHub Data
       run: |
         uv run gitmetrics consolidate \
-          --config-file weekly_extraction_config.yaml \
+          --config-file weekly_extraction_config.yaml monthly_extraction_config.yaml \
           --output-folder ${{ secrets.OUTPUT_FOLDER }}
       env:
         PYDRIVE_CREDENTIALS: ${{ secrets.PYDRIVE_CREDENTIALS }}

--- a/gitmetrics/__main__.py
+++ b/gitmetrics/__main__.py
@@ -140,11 +140,13 @@ def _summarize(args, parser):
 
 
 def _consolidate(args, parser):
-    config = _load_config(args.config_file)
-    projects = config['projects']
+    all_projects = []
+    for config_file in args.config_file:
+        config = _load_config(config_file)
+        all_projects.extend(config.get('projects', []))
 
     consolidate_metrics(
-        projects=projects,
+        projects=all_projects,
         output_folder=args.output_folder,
         dry_run=args.dry_run,
         verbose=args.verbose,
@@ -223,8 +225,9 @@ def _get_parser():
         '-c',
         '--config-file',
         type=str,
-        default=DEFAULT_PROJECT_DEFINITIONS,
-        help='Path to the configuration file.',
+        nargs='+',
+        default=[DEFAULT_PROJECT_DEFINITIONS],
+        help='Path(s) to configuration file(s).',
     )
     consolidate.add_argument(
         '-d',

--- a/gitmetrics/consolidate.py
+++ b/gitmetrics/consolidate.py
@@ -12,6 +12,7 @@ from gitmetrics.constants import (
     METRICS_SHEET_NAME,
     VALUE_COLUMN_NAME,
 )
+from gitmetrics.drive import _get_drive_client, is_drive_path, split_drive_path
 from gitmetrics.output import create_spreadsheet, load_spreadsheet
 
 OUTPUT_FILENAME = 'gitmetrics_consolidated_summary_to_date'
@@ -62,6 +63,21 @@ def consolidate_metrics(projects, output_folder, dry_run=False, verbose=True):
     if verbose:
         LOGGER.info(f'Sheet Name: {SHEET_NAME}')
         LOGGER.info(consolidated_df.to_string())
+
     if not dry_run:
         output_path = os.path.join(output_folder, OUTPUT_FILENAME)
+        create_spreadsheet(output_path=output_path, sheets=sheets)
+
+    if is_drive_path(output_folder):
+        drive = _get_drive_client()
+        gdrive_folder = output_folder.rstrip('/') + '/'
+        folder_id, _ = split_drive_path(gdrive_folder)
+
+        folder = drive.CreateFile({'id': folder_id})
+        folder.FetchMetadata(fields='parents')
+
+        parents = folder.get('parents') or []
+        parent_id = parents[0].get('id')
+
+        output_path = f'gdrive://{parent_id}/{OUTPUT_FILENAME}'
         create_spreadsheet(output_path=output_path, sheets=sheets)

--- a/gitmetrics/consolidate.py
+++ b/gitmetrics/consolidate.py
@@ -56,6 +56,7 @@ def consolidate_metrics(projects, output_folder, dry_run=False, verbose=True):
         row_info.update(row_values)
         if verbose:
             LOGGER.info(f' {project} values: {row_info}')
+
         rows.append(row_info)
 
     consolidated_df = pd.DataFrame(rows)
@@ -66,7 +67,6 @@ def consolidate_metrics(projects, output_folder, dry_run=False, verbose=True):
 
     if not dry_run:
         output_path = os.path.join(output_folder, OUTPUT_FILENAME)
-        create_spreadsheet(output_path=output_path, sheets=sheets)
 
     if is_drive_path(output_folder):
         drive = _get_drive_client()
@@ -80,4 +80,7 @@ def consolidate_metrics(projects, output_folder, dry_run=False, verbose=True):
         parent_id = parents[0].get('id')
 
         output_path = f'gdrive://{parent_id}/{OUTPUT_FILENAME}'
+        create_spreadsheet(output_path=output_path, sheets=sheets)
+
+    else:
         create_spreadsheet(output_path=output_path, sheets=sheets)

--- a/gitmetrics/drive.py
+++ b/gitmetrics/drive.py
@@ -98,7 +98,7 @@ def upload_spreadsheet(content, filename, folder):
     retries = 0
     while retries != MAX_UPLOAD_RETRIES:
         try:
-            if drive_file['mimeType'] == SPREADSHEET_MIMETYPE:
+            if drive_file.get('mimeType') == SPREADSHEET_MIMETYPE:
                 drive_file.Upload()
             else:
                 drive_file.Upload({'convert': True})

--- a/monthly_extraction_config.yaml
+++ b/monthly_extraction_config.yaml
@@ -8,4 +8,3 @@ projects:
   scikit-learn:
   ray:
   airbyte:
-  PyTorchLightning:

--- a/weekly_extraction_config.yaml
+++ b/weekly_extraction_config.yaml
@@ -11,3 +11,4 @@ projects:
   pycaret:
   snorkel:
   spacy:
+  PyTorchLightning:


### PR DESCRIPTION
Updates to the monthly workflow:
1. Set the proper environment (weekly) since it shares same output folder for now.
2. Moved one library to the weekly in order to give a bit more margin on the monthly run. (with PyTorchLightning it takes 5 hours 51 minutes -- moving it will save us ~20-25 minutes).
3. Updated the code that generates the consolidated overview to write to the parent gdrive folder.
4. Make that consolidate will write for both monthly and weekly combined.